### PR TITLE
Stringify and upcase operation_name when starting a new span

### DIFF
--- a/faraday-tracer.gemspec
+++ b/faraday-tracer.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'faraday-tracer'
-  spec.version       = '0.1.1'
+  spec.version       = '0.1.2'
   spec.authors       = ['SaleMove TechMovers']
   spec.email         = ['techmovers@salemove.com']
 

--- a/faraday-tracer.gemspec
+++ b/faraday-tracer.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'faraday'
 end

--- a/lib/faraday/tracer.rb
+++ b/lib/faraday/tracer.rb
@@ -10,7 +10,7 @@ module Faraday
     end
 
     def call(env)
-      span = @tracer.start_span(env[:method],
+      span = @tracer.start_span(env[:method].to_s.upcase,
         child_of: @parent_span,
         tags: {
           'component' => 'faraday',

--- a/spec/faraday/support/recording_tracer.rb
+++ b/spec/faraday/support/recording_tracer.rb
@@ -1,0 +1,34 @@
+class RecordingTracer
+  attr_reader :finished_spans
+
+  def initialize
+    @finished_spans = []
+  end
+
+  def start_span(operation_name, **)
+    Span.new(self, operation_name)
+  end
+
+  def inject(*)
+  end
+
+  class Span
+    attr_reader :operation_name
+
+    def initialize(tracer, operation_name)
+      @tracer = tracer
+      @operation_name = operation_name
+    end
+
+    def finish
+      @tracer.finished_spans << self
+    end
+
+    def context
+      {}
+    end
+
+    def set_tag(*)
+    end
+  end
+end

--- a/spec/faraday/tracer_spec.rb
+++ b/spec/faraday/tracer_spec.rb
@@ -1,4 +1,20 @@
 require 'spec_helper'
+require_relative './support/recording_tracer'
 
 RSpec.describe Faraday::Tracer do
+  let(:tracer) { RecordingTracer.new }
+
+  it 'uses upcase HTTP method as span operation name' do
+    call(method: :post)
+    span = tracer.finished_spans.first
+    expect(span.operation_name).to eq('POST')
+  end
+
+  def call(options)
+    app = lambda {|env| env}
+    env = Faraday::Env.from(options)
+    allow(env).to receive(:on_complete).and_yield(double(status: 200))
+    middleware = described_class.new(app, tracer: tracer)
+    middleware.call(env)
+  end
 end


### PR DESCRIPTION
`OpenTracing::Tracer` contract says that we need to use a string as the
operation name. Previously we were using a symbol. Not all tracers can handle
symbols.