### PR TITLE
Contribution README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/salemove/faraday-tracer.
+Bug reports and pull requests are welcome on GitHub at https://github.com/opentracing-contrib/ruby-faraday-tracer.
 
 
 ## License


### PR DESCRIPTION
Originally the gem and repo was maintained under salemove organization,
currently opentracing-contrib. Previously the repo was named faraday-tracer,
now more specific ruby-faraday-tracer. The documentation still points
to the previous repo url. The PR updates the outdated information. 