### PR TITLE
Allow to pass Proc as parent span provider

### DIFF
--- a/lib/faraday/tracer.rb
+++ b/lib/faraday/tracer.rb
@@ -3,6 +3,14 @@ require 'opentracing'
 
 module Faraday
   class Tracer < Faraday::Middleware
+    # Create a new Faraday Tracer middleware.
+    #
+    # @param app The faraday application/middlewares stack.
+    # @param span [Span, SpanContext, Proc, nil] SpanContext that acts as a parent to
+    #        the newly-started by the middleware Span. If a Proc is provided, its
+    #        evaluated during the call method invocation.
+    # @param tracer [OpenTracing::Tracer] A tracer to be used when start_span, and inject
+    #        is called.
     def initialize(app, span: nil, tracer: OpenTracing.global_tracer)
       super(app)
       @tracer = tracer
@@ -11,7 +19,7 @@ module Faraday
 
     def call(env)
       span = @tracer.start_span(env[:method].to_s.upcase,
-        child_of: @parent_span,
+        child_of: @parent_span.respond_to?(:call) ? @parent_span.call : @parent_span,
         tags: {
           'component' => 'faraday',
           'span.kind' => 'client',

--- a/spec/faraday/tracer_spec.rb
+++ b/spec/faraday/tracer_spec.rb
@@ -16,11 +16,28 @@ RSpec.describe Faraday::Tracer do
     expect(span.tags['span.kind']).to eq('client')
   end
 
+  describe 'parent_span' do
+    it 'allows to pass a pre-created parent span' do
+      parent_span = tracer.start_span("parent_span")
+      expect(tracer).to receive(:start_span).with(any_args, hash_including(child_of: parent_span)).and_call_original
+      call(method: :post, span: parent_span)
+    end
+
+    it 'allows to pass a block as a parent span provider' do
+      parent_span = tracer.start_span("parent_span")
+      parent_span_provider = lambda { parent_span }
+
+      expect(tracer).to receive(:start_span).with(any_args, hash_including(child_of: parent_span)).and_call_original
+      call(method: :post, span: parent_span_provider)
+    end
+  end
+
   def call(options)
+    span = options.delete(:span)
     app = lambda {|env| env}
     env = Faraday::Env.from(options)
     allow(env).to receive(:on_complete).and_yield(double(status: 200))
-    middleware = described_class.new(app, tracer: tracer)
+    middleware = described_class.new(app, span: span, tracer: tracer)
     middleware.call(env)
   end
 end


### PR DESCRIPTION
The PR introduces an ability to pass a Proc as a parent span provider to the middleware. Sometimes you have very restricted access to the Faraday's stack e.g. when you use a third-party client libraries which underneath use Faraday. Often libraries hide when and how often Faraday stack is created. If you're lucky, you're allowed to set an additional middleware during library initialization. By passing a Proc we can dynamically supply a parent span, and allow for Faraday client, and stack reuse by this-party libraries. The change is fully backwards compatible.