### PR TITLE
Add exception handling to the middleware

### DIFF
--- a/spec/faraday/tracer_spec.rb
+++ b/spec/faraday/tracer_spec.rb
@@ -32,9 +32,42 @@ RSpec.describe Faraday::Tracer do
     end
   end
 
+  describe 'error handling' do
+    it 'finishes the span' do
+      expect { call(app: lambda {|env| raise Timeout::Error }) }.to raise_error { |_|
+        expect(tracer.finished_spans.first).not_to be_nil
+      }
+    end
+
+    it 'marks the span as failed' do
+      expect { call(app: lambda {|env| raise Timeout::Error }) }.to raise_error { |_|
+        span = tracer.finished_spans.first
+
+        expect(span.tags['error']).to eq(true)
+      }
+    end
+
+    it 'logs the error' do
+      exception = Timeout::Error.new
+      expect { call(app: lambda {|env| raise exception }) }.to raise_error { |thrown_exception|
+        span = tracer.finished_spans.first
+        log = span.logs.first
+
+        expect(span.logs).not_to be_empty
+        expect(log[:event]).to eq('error')
+        expect(log[:fields][:'error.object']).to eq(thrown_exception)
+        expect(log[:fields][:'error.object']).to eq(exception)
+      }
+    end
+
+    it 're-raise original exception' do
+      expect { call(app: lambda {|env| raise Timeout::Error }) }.to raise_error(Timeout::Error)
+    end
+  end
+
   def call(options)
     span = options.delete(:span)
-    app = lambda {|env| env}
+    app = options.delete(:app) || lambda {|env| env}
     env = Faraday::Env.from(options)
     allow(env).to receive(:on_complete).and_yield(double(status: 200))
     middleware = described_class.new(app, span: span, tracer: tracer)


### PR DESCRIPTION
The change allows to set an explicit array of errors to be captured by the tracer as errors. 
Notice that errors are **not** muted by the middleware, they are re-raised afterwards. So for example it's safe to capture interrupts or related, and still they will bubble up. 
By default all the standard exceptions are captured.

When an exception occurs, as described in the OT specification the following operations are performed:
* we mark the span as failed by setting `error` tag to `true`
* we log the error by setting `event` to `error`, and `error.object` to the thrown exception.