### PR TITLE
Allow setting span in the request builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,35 @@ gem 'faraday-tracer'
 
 ## Usage
 
+### Using request context
+
+```ruby
+require 'opentracing'
+OpenTracing.global_tracer = TracerImplementation.new
+
+require 'faraday'
+require 'faraday/tracer'
+
+conn = Faraday.new(url: 'http://localhost:3000/') do |faraday|
+  # Add tracing support
+  faraday.use Faraday::Tracer
+
+  # default Faraday stack
+  faraday.request :url_encoded
+  faraday.adapter Faraday.default_adapter
+end
+
+span = request.env['rack.span'] # when using rack-tracer gem
+
+conn.post('/test') do |request|
+  # Leave undefined or set span to nil if there's no existing span
+  request.options.context = {span: span}
+end
+```
+
+
+### Defining span in the connection builder
+
 ```ruby
 require 'opentracing'
 OpenTracing.global_tracer = TracerImplementation.new

--- a/spec/faraday/tracer_spec.rb
+++ b/spec/faraday/tracer_spec.rb
@@ -3,63 +3,94 @@ require 'spec_helper'
 RSpec.describe Faraday::Tracer do
   let(:tracer) { Test::Tracer.new }
 
-  it 'uses upcase HTTP method as span operation name' do
-    call(method: :post)
-    expect(tracer).to have_span('POST').finished
+  shared_examples 'tracing' do |request_method|
+    let(:make_request) { method(request_method) }
+
+    it 'uses upcase HTTP method as span operation name' do
+      make_request.call(method: :post)
+      expect(tracer).to have_span('POST').finished
+    end
+
+    it 'sets span.kind to client' do
+      make_request.call(method: :post)
+      expect(tracer).to have_span.with_tag('span.kind', 'client')
+    end
+
+    describe 'parent_span' do
+      it 'allows to pass a pre-created parent span' do
+        parent_span = tracer.start_span("parent_span")
+        expect(tracer).to receive(:start_span).with(any_args, hash_including(child_of: parent_span)).and_call_original
+        make_request.call(method: :post, span: parent_span)
+      end
+
+      it 'allows to pass a block as a parent span provider' do
+        parent_span = tracer.start_span("parent_span")
+        parent_span_provider = lambda { parent_span }
+
+        expect(tracer).to receive(:start_span).with(any_args, hash_including(child_of: parent_span)).and_call_original
+        make_request.call(method: :post, span: parent_span_provider)
+      end
+    end
+
+    describe 'error handling' do
+      it 'finishes the span' do
+        expect { make_request.call(app: lambda {|env| raise Timeout::Error }) }.to raise_error { |_|
+          expect(tracer).to have_spans.finished
+        }
+      end
+
+      it 'marks the span as failed' do
+        expect { make_request.call(app: lambda {|env| raise Timeout::Error }) }.to raise_error { |_|
+          expect(tracer).to have_span.with_tag('error', true)
+        }
+      end
+
+      it 'logs the error' do
+        exception = Timeout::Error.new
+        expect { make_request.call(app: lambda {|env| raise exception }) }.to raise_error { |thrown_exception|
+          expect(tracer).to have_span.with_log(event: 'error', :'error.object' => thrown_exception)
+        }
+      end
+
+      it 're-raise original exception' do
+        expect { make_request.call(app: lambda {|env| raise Timeout::Error }) }.to raise_error(Timeout::Error)
+      end
+    end
   end
 
-  it 'sets span.kind to client' do
-    call(method: :post)
-    expect(tracer).to have_span.with_tag('span.kind', 'client')
+  context 'when span is defined using the builder' do
+    include_examples 'tracing', :make_builder_request
   end
 
-  describe 'parent_span' do
-    it 'allows to pass a pre-created parent span' do
-      parent_span = tracer.start_span("parent_span")
-      expect(tracer).to receive(:start_span).with(any_args, hash_including(child_of: parent_span)).and_call_original
-      call(method: :post, span: parent_span)
-    end
-
-    it 'allows to pass a block as a parent span provider' do
-      parent_span = tracer.start_span("parent_span")
-      parent_span_provider = lambda { parent_span }
-
-      expect(tracer).to receive(:start_span).with(any_args, hash_including(child_of: parent_span)).and_call_original
-      call(method: :post, span: parent_span_provider)
-    end
+  context 'when span is defined in the request context' do
+    include_examples 'tracing', :make_explicit_request
   end
 
-  describe 'error handling' do
-    it 'finishes the span' do
-      expect { call(app: lambda {|env| raise Timeout::Error }) }.to raise_error { |_|
-        expect(tracer).to have_spans.finished
-      }
+  def make_builder_request(options)
+    app = options.delete(:app) || lambda {|app_env| [200, {}, 'OK']}
+
+    connection = Faraday.new do |builder|
+      builder.use Faraday::Tracer, span: options[:span], tracer: tracer
+      builder.adapter :test do |stub|
+        stub.post('/', &app)
+      end
     end
 
-    it 'marks the span as failed' do
-      expect { call(app: lambda {|env| raise Timeout::Error }) }.to raise_error { |_|
-        expect(tracer).to have_span.with_tag('error', true)
-      }
-    end
-
-    it 'logs the error' do
-      exception = Timeout::Error.new
-      expect { call(app: lambda {|env| raise exception }) }.to raise_error { |thrown_exception|
-        expect(tracer).to have_span.with_log(event: 'error', :'error.object' => thrown_exception)
-      }
-    end
-
-    it 're-raise original exception' do
-      expect { call(app: lambda {|env| raise Timeout::Error }) }.to raise_error(Timeout::Error)
-    end
+    connection.post('/')
   end
 
-  def call(options)
-    span = options.delete(:span)
-    app = options.delete(:app) || lambda {|env| env}
-    env = Faraday::Env.from(options)
-    allow(env).to receive(:on_complete).and_yield(double(status: 200))
-    middleware = described_class.new(app, span: span, tracer: tracer)
-    middleware.call(env)
+  def make_explicit_request(options)
+    app = options.delete(:app) || lambda {|app_env| [200, {}, 'OK']}
+
+    connection = Faraday.new do |builder|
+      builder.use Faraday::Tracer, tracer: tracer
+      builder.adapter :test do |stub|
+        stub.post('/', &app)
+      end
+    end
+
+    connection.post('/') do |request|
+      request.options.context = {span: options[:span]}
+    end
   end
 end


### PR DESCRIPTION
Previously it was only possible using the connection builder. This
however is not very convenient as many application create a one
connection object in the initializer and use it multiple times. It's
more convenient to specify the span in the request builder instead.