### PR TITLE
Check for existence of context member for older Faraday releases

### DIFF
--- a/lib/faraday/tracer.rb
+++ b/lib/faraday/tracer.rb
@@ -58,12 +58,12 @@ module Faraday
     private
 
     def span_name(env)
-      context = env.request.context
+      context = env.request.context if env.request.respond_to?(:context)
       context.is_a?(Hash) && context[:span_name] || @span_name || env[:method].to_s.upcase
     end
 
     def parent_span(env)
-      context = env.request.context
+      context = env.request.context if env.request.respond_to?(:context)
       span = context.is_a?(Hash) && context[:span] || @parent_span
       return unless span
 
@@ -86,7 +86,7 @@ module Faraday
     end
 
     def peer_service(env)
-      context = env.request.context
+      context = env.request.context if env.request.respond_to?(:context)
       context.is_a?(Hash) && context[:service_name] || @service_name
     end
   end


### PR DESCRIPTION
The context member doesn't exist prior to `0.12.0`: https://github.com/lostisland/faraday/commit/617c909c9c1bd5955537b4e4646744fc9bd8bfe1#diff-32dfef617839b0b1d5f792c3d3da8420

This adds compatibility with older versions.